### PR TITLE
Add hint to error message

### DIFF
--- a/pytest_steps/steps_generator.py
+++ b/pytest_steps/steps_generator.py
@@ -310,7 +310,8 @@ class StepsMonitor(object):
             elif isinstance(res, optional_step):
                 # optional step: check if the execution went well
                 if res.exec_result is None:
-                    raise ValueError("Internal error: this should not happen")
+                    raise ValueError("Internal error: this should not happen."
+                                     "Did you ``yield step_b`` inside the context manager instead of after it?")
 
                 elif isinstance(res.exec_result, OptionalStepException):
                     # An exception happened in the optional step. We can now raise it safely


### PR DESCRIPTION
I was playing with the tutorial at https://smarie.github.io/python-pytest-steps/#c-optional-steps-and-dependencies and got this error.

I had indented badly and my code looked like this: 
    with optional_step('step_b') as step_b:
        assert True
        yield step_b # should have been unindented, caused this error.

I just wanted to help any other newbie get past this in case it happened to them.