### PR TITLE
update setup/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pytest -v pytest_steps/tests/
 You may need to install requirements for setup beforehand, using 
 
 ```bash
-pip install -r ci_tools/requirements-test.txt
+pip install -e .[test]
 ```
 
 ## Packaging
@@ -53,7 +53,7 @@ mkdocs build -f docs/mkdocs.yml
 You may need to install requirements for doc beforehand, using 
 
 ```bash
-pip install -r ci_tools/requirements-doc.txt
+pip install -e .[doc]
 ```
 
 ## Generating the test reports

--- a/pytest_steps/tests/test_with_cases.py
+++ b/pytest_steps/tests/test_with_cases.py
@@ -1,4 +1,4 @@
-from pytest_cases import cases_data
+from pytest_cases import parametrize_with_cases
 from pytest_steps import test_steps
 
 
@@ -7,7 +7,7 @@ def case_dummy():
 
 
 @test_steps('a', 'b')
-@cases_data(cases=case_dummy)
+@parametrize_with_cases('case_data', cases=".")
 def test_basic_modeling(case_data):
     yield 'a'
     yield 'b'

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,9 @@ from setuptools_scm import get_version  # noqa: E402
 INSTALL_REQUIRES = ['makefun>=1.5', 'wrapt', 'functools32;python_version<"3.2"', 'funcsigs;python_version<"3.3"', 'six']
 DEPENDENCY_LINKS = []
 SETUP_REQUIRES = ['pytest-runner', 'setuptools_scm']
-TESTS_REQUIRE = ['pytest', 'pytest-logging', 'pytest-harvest>=1.4.0', 'pytest-cases']
-EXTRAS_REQUIRE = {}
+TESTS_REQUIRE = ['pytest', 'pytest-logging', 'pytest-harvest>=1.4.0', 'pytest-cases', 'tabulate', 'pandas', ]
+DOCS_REQUIRE = [ 'mkdocs', 'mkdocs-material' ] 
+EXTRAS_REQUIRE = {'test': TESTS_REQUIRE, 'doc': DOCS_REQUIRE }
 
 # ************** ID card *****************
 DISTNAME = 'pytest-steps'
@@ -109,7 +110,7 @@ setup(
 
     # test
     # test_suite='nose.collector',
-    tests_require=TESTS_REQUIRE,
+    # tests_require=TESTS_REQUIRE,
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Fixes misc setup issues when starting to work with this repo in a new environment

1. Removes references from README.md to files that do not exist, use new "extras" defined in setup.py
2. Fixes broken test_with_cases test (but there are still two pandas deprecation warnings lurking about the test suite)
3. removes tests_require (obsolete feature of setuptools) and uses extras_require instead
4. add additional libraries to "test" extras to run all tests, add "doc" extras for making the docs

possible other lurking bug: I could not get the "ant" command referred to in the README to run on my computer