### PR TITLE
Fix typo for note

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,7 @@ Start with you favorite test function. There are two things to do, to break it d
  - insert as many `yield` statements in your function body as there are steps. The function should end with a `yield` (not `return`!). 
  
  !!! note
+ 
    Code written after the last yield will not be executed. 
 
 For example we define three steps:


### PR DESCRIPTION
Fix a small typo / syntax issue for markdown note

Currently it looks like this

![image](https://user-images.githubusercontent.com/576771/190004344-54406bb0-3108-41c0-ab19-9ec7fd3dd3b9.png)
