### PR TITLE
Fix pip install command on help page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,7 @@ With `pytest-steps` you don't have to care about the internals: it just works as
 ## Installing
 
 ```bash
-> pip install pytest_steps
+> pip install pytest-steps
 ```
 
 ## 1. Usage - "generator" mode


### PR DESCRIPTION
This will fix the "pip install" command on the help page. The package was written with an underscore "pytest_steps", which is irritating, because everywhere else, even on pypi.org, it is written with a dash.